### PR TITLE
Use gethostname on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+script:
+  - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ rust:
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
+
 script:
   - cargo test
+
+notifications:
+  email:
+    on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/lib.rs"
 [features]
 unstable = []
 
-[target."cfg(unix)".dependencies]
+[dependencies]
 libc = "^0.2"
 
 [target."cfg(windows)".dependencies]
-winutil = "^0.1"
+winapi = { version = "~0.3", features = ["winsock2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ unstable = []
 libc = "^0.2"
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "~0.3", features = ["winsock2"] }
+winapi = { version = "~0.3", features = ["sysinfoapi"] }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+environment:
+
+  # At the time this was added AppVeyor was having troubles with checking
+  # revocation of SSL certificates of sites like static.rust-lang.org and what
+  # we think is crates.io. The libcurl HTTP client by default checks for
+  # revocation on Windows and according to a mailing list [1] this can be
+  # disabled.
+  #
+  # The `CARGO_HTTP_CHECK_REVOKE` env var here tells cargo to disable SSL
+  # revocation checking on Windows in libcurl. Note, though, that rustup, which
+  # we're using to download Rust here, also uses libcurl as the default backend.
+  # Unlike Cargo, however, rustup doesn't have a mechanism to disable revocation
+  # checking. To get rustup working we set `RUSTUP_USE_HYPER` which forces it to
+  # use the Hyper instead of libcurl backend. Both Hyper and libcurl use
+  # schannel on Windows but it appears that Hyper configures it slightly
+  # differently such that revocation checking isn't turned on by default.
+  #
+  # [1]: https://curl.haxx.se/mail/lib-2016-03/0202.html
+  RUSTUP_USE_HYPER: 1
+  CARGO_HTTP_CHECK_REVOKE: false
+
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+install:
+  - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo build
+  - cargo test


### PR DESCRIPTION
The Windows implementation was using `GetComputerName` even though
`gethostname` is available on Windows, so I updated to the latest winapi
instead of winutil.

Also added CI.