### PR TITLE
expand `windows` version range to include `0.58` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cfg-if = "^1.0"
 libc = "^0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "^0.54", features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
+windows = { version = ">=0.52, <=0.58", features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cfg-if = "^1.0"
 libc = "^0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "^0.52", features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
+windows = { version = "^0.54", features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 version-sync = "0.9"


### PR DESCRIPTION
to avoid dependencies to multiple versions of the windows crate in [uutils](https://github.com/uutils/coreutils), I would like to bump on this crate the windows create version.

tested manually on my ubuntu AND my Windows 11. Compiles and all tests green.