### PR TITLE
Upgrade `windows` crate to `0.59` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cfg-if = "^1.0"
 libc = "^0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "^0.52", features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
+windows = { version = "0.59", features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -17,7 +17,11 @@ pub fn get() -> io::Result<OsString> {
         // Don't care much about the result here,
         // it is guaranteed to return an error,
         // since we passed the NULL pointer as a buffer
-        let result = GetComputerNameExW(ComputerNamePhysicalDnsHostname, PWSTR::null(), &mut size);
+        let result = GetComputerNameExW(
+            ComputerNamePhysicalDnsHostname,
+            Some(PWSTR::null()),
+            &mut size,
+        );
         debug_assert!(result.is_err());
     };
 
@@ -26,7 +30,7 @@ pub fn get() -> io::Result<OsString> {
     let result = unsafe {
         GetComputerNameExW(
             ComputerNamePhysicalDnsHostname,
-            PWSTR::from_raw(buffer.as_mut_ptr()),
+            Some(PWSTR::from_raw(buffer.as_mut_ptr())),
             &mut size,
         )
     };


### PR DESCRIPTION
`windows 0.59` recently dropped at https://github.com/microsoft/windows-rs/releases/tag/0.61.0 (wrong tag), and unfortunately requires some code changes compared to previous releases.
