### PR TITLE
chore: relax `windows-link` version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-link = "0.1.1"
+windows-link = "0.1.0"
 
 [dev-dependencies]
 version-sync = "0.9"


### PR DESCRIPTION
Trying to update `hostname` in our dependency graph currently fails with the following:

```
❯ cargo check
error: failed to select a version for `windows-link`.
    ... required by package `windows v0.60.0`
    ... which satisfies dependency `windows = "^0.60"` (locked to 0.60.0) of package `tauri v2.4.1`
    ... which satisfies dependency `tauri = "^2.4.1"` (locked to 2.4.1) of package `firezone-gui-client v1.4.10 (/home/thomas/src/github.com/firezone/firezone/rust/gui-client/src-tauri)`
versions that meet the requirements `^0.1.0` (locked to 0.1.0) are: 0.1.0

all possible versions conflict with previously selected packages.

  previously selected package `windows-link v0.1.1`
    ... which satisfies dependency `windows-link = "^0.1.1"` of package `hostname v0.4.1`
    ... which satisfies dependency `hostname = "^0.4.0"` (locked to 0.4.1) of package `phoenix-channel v0.1.0 (/home/thomas/src/github.com/firezone/firezone/rust/phoenix-channel)`
    ... which satisfies path dependency `phoenix-channel` (locked to 0.1.0) of package `connlib-client-android v1.4.6 (/home/thomas/src/github.com/firezone/firezone/rust/connlib/clients/android)`

failed to select a version for `windows-link` which could resolve this conflict
```

From looking at the version history of `windows-link`, it doesn't look like anything important was merged in `0.1.1` so I think relaxing this requirement down to `0.1.0` should be okay.