### PR TITLE
Bump `windows-link` dependency `0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-link = "0.1.1"
+windows-link = "0.2"
 
 [dev-dependencies]
 version-sync = "0.9"


### PR DESCRIPTION
- https://github.com/microsoft/windows-rs/releases/tag/69

Unsure when the `.1` point release was made, the release notes are too inconsistent to tell.
