### PR TITLE
Release `0.4.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2025-11-25
+
+- Bumped `windows-link` dependency from `0.1.1` to `0.2` (#33)
+
+## [0.4.1] - 2025-04-08
+
 ## [0.4.0] - 2024-04-01
 
 ### Added
@@ -60,3 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `get_hostname` function is deprecated and marked to be removed in the upcoming `0.3.0` version
+
+[0.4.2]: https://github.com/djc/hostname/releases/tag/v0.4.2
+[0.4.1]: https://github.com/djc/hostname/releases/tag/v0.4.1
+[0.4.0]: https://github.com/djc/hostname/releases/tag/v0.4.0
+[0.3.1]: https://github.com/djc/hostname/releases/tag/v0.3.1
+[0.3.0]: https://github.com/djc/hostname/releases/tag/v0.3.0
+[0.2.0]: https://github.com/djc/hostname/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostname"
-version = "0.4.1"
+version = "0.4.2"
 description = "Cross-platform system's host name functions"
 categories = ["api-bindings", "os"]
 keywords = ["hostname", "gethostname", "sethostname"]


### PR DESCRIPTION
For https://github.com/djc/hostname/pull/33
